### PR TITLE
signature_downloader: Dockerfile のベースイメージを debian:trixie-slim に変更し、downloader.sh にエラーハンドリングを追加

### DIFF
--- a/signature_downloader/Dockerfile
+++ b/signature_downloader/Dockerfile
@@ -1,16 +1,20 @@
-FROM ubuntu:latest
+FROM debian:trixie-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    apt update && \
-    apt install -y clamav-freshclam curl unzip && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates clamav-freshclam curl tzdata unzip && \
+    ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     dpkg-reconfigure --frontend noninteractive tzdata && \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o awscliv2.zip && \
     unzip awscliv2.zip && \
     ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     mkdir -p /tmp/clamdb && \
-    chown -R 101:102 /tmp/clamdb
+    chown -R clamav:clamav /tmp/clamdb
 
 COPY freshclam.conf /etc/clamav/freshclam.conf
 COPY downloader.sh /usr/local/bin/downloader.sh

--- a/signature_downloader/downloader.sh
+++ b/signature_downloader/downloader.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "Start ClamAV signatures uploaded to S3."
 


### PR DESCRIPTION
## 背景

`signature_downloader/Dockerfile` のベースイメージが `ubuntu:latest` のため、Critical な CVE が継続的に発生していました。また、`downloader.sh` にエラーハンドリングがなく、`freshclam` が失敗しても後続の `aws s3 cp` が実行されてしまい、古い or 空の signature database が S3 ミラーに上書きされる可能性がありました。

## 変更内容

### `signature_downloader/Dockerfile`

- ベースイメージ `ubuntu:latest` → `debian:trixie-slim`
- `apt` → `apt-get` (非対話用) に変更、`--no-install-recommends` を追加
- `apt-get clean && rm -rf /var/lib/apt/lists/*` で apt キャッシュ削除
- `awscliv2.zip` と展開先 `aws/` を `./aws/install` 後に削除
- `ca-certificates` / `tzdata` を明示的に install (`--no-install-recommends` 化に伴い recommends が来なくなったため)
- `chown 101:102` を `chown clamav:clamav` に変更（`clamav-freshclam` パッケージが作成する named user を参照し、uid/gid 数値ズレを回避）

### `signature_downloader/downloader.sh`

- 先頭に `set -euo pipefail` を追加
  - `freshclam` 失敗時に後続の `aws s3 cp` が走り、古い or 空の `.cvd` で S3 ミラーを上書きするのを防ぐ

## 動作確認

- `docker build --platform linux/arm64 -t test signature_downloader/` がローカルで成功
- ビルドした image 内で `freshclam --version` (1.4.3) / `aws --version` (2.34.45) が動作することを確認