### PR TITLE
ci: signiture_downloader のビルド・プッシュワークフローを追加

### DIFF
--- a/.github/workflows/build_and_push_signiture_downloader.yml
+++ b/.github/workflows/build_and_push_signiture_downloader.yml
@@ -1,0 +1,37 @@
+name: Build and Push (signiture_downloader)
+on:
+  workflow_dispatch:
+    inputs:
+      build_target:
+        description: Tag name or branch name to deploy e.g. main, develop, v1.0.0 etc.
+        default: main
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  build-and-push-container:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.build_target }}
+      - name: Login to Dockerhub
+        id: login-dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Get image tag
+        id: get-image-tag
+        run: |
+          SHORT_COMMIT_ID=`git rev-parse --short HEAD`
+          REF=`echo ${{ github.event.inputs.build_target }} | sed  -e 's/\//-/g'`
+          echo "image-tag=${REF}-${SHORT_COMMIT_ID}" >> $GITHUB_OUTPUT
+      - name: Build and push container image
+        uses: docker/build-push-action@v6
+        with:
+          context: signature_downloader
+          push: true
+          tags: fufuhu/go-clamav-signiture-downloader:${{ steps.get-image-tag.outputs.image-tag }}


### PR DESCRIPTION
## Summary
- issue #8 対応
- `signature_downloader/` の Dockerfile をビルドして `fufuhu/go-clamav-signiture-downloader` に push する `workflow_dispatch` ワークフローを追加
- 既存の `build_and_push.yml` をベースに、`context: signature_downloader` とイメージ名のみ差し替え

Closes #8

## Test plan
- [ ] Actions の "Build and Push (signiture_downloader)" を `workflow_dispatch` で起動し、Docker Hub に `fufuhu/go-clamav-signiture-downloader:<ref>-<sha>` が push されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)